### PR TITLE
Logout in settings + Onboarding fix

### DIFF
--- a/app/src/main/java/com/business/fityou/MainActivity.kt
+++ b/app/src/main/java/com/business/fityou/MainActivity.kt
@@ -67,6 +67,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        unregisterReceiver(updateTime)
         stopService(serviceIntent)
     }
 

--- a/app/src/main/java/com/business/fityou/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/business/fityou/data/repository/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.business.fityou.data.repository
 import android.app.Application
 import android.content.Intent
 import android.content.IntentSender
+import android.content.SharedPreferences
 import android.util.Log
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
@@ -19,7 +20,8 @@ import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val googleAuthClient: GoogleAuthClient,
-    private val auth: FirebaseAuth
+    private val auth: FirebaseAuth,
+    private val pref: SharedPreferences
 ) : UserRepository {
 
     private val fireStoreUserCollection = Firebase.firestore.collection("users")
@@ -79,4 +81,6 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override fun getCurrentUser(): FirebaseUser? = auth.currentUser
+    override fun isFirstTime(): Boolean = pref.getBoolean("firstTime", true)
+    override fun noLongerFirstTime() = pref.edit().putBoolean("firstTime", false).apply()
 }

--- a/app/src/main/java/com/business/fityou/domain/UserRepository.kt
+++ b/app/src/main/java/com/business/fityou/domain/UserRepository.kt
@@ -24,4 +24,7 @@ interface UserRepository {
     suspend fun logOutUser()
 
     fun getCurrentUser(): FirebaseUser?
+
+    fun isFirstTime(): Boolean
+    fun noLongerFirstTime()
 }

--- a/app/src/main/java/com/business/fityou/ui/composables/home/HomeScreen.kt
+++ b/app/src/main/java/com/business/fityou/ui/composables/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.business.fityou.ui.composables.home
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -15,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -41,29 +43,26 @@ fun HomeScreen(
     scaffoldState: ScaffoldState
 ) = with(workoutViewModel) {
 
-
-    getUser(userViewModel.signInState)
-    getWorkoutPlan()
-    getExercises()
-
     val scope = rememberCoroutineScope()
     val state = workoutPlanState
     val date = workoutDay
     val selectedDay = calendarSelection
     var delay by remember { mutableStateOf(true) }
     var openDialog by remember { mutableStateOf(false) }
-    var openLogoutDialog by remember { mutableStateOf(false) }
+    var openExitDialog by remember { mutableStateOf(false) }
+    val ctx = LocalContext.current as? Activity
+
+    LaunchedEffect(Unit) {
+        getUser(userViewModel.signInState)
+        getWorkoutPlan()
+        getExercises()
+    }
 
     // There's a log out button in the profile menu. If that one
     //      is preferred, you can remove this.
-    BackHandler(true) {
+    BackHandler(true) { openExitDialog = true }
 
-        openLogoutDialog = true
-    }
-
-    LaunchedEffect(key1 = openDialog){
-        getWorkoutPlan()
-    }
+    LaunchedEffect(key1 = openDialog){ getWorkoutPlan() }
 
     Surface(
         modifier = Modifier
@@ -95,7 +94,7 @@ fun HomeScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(300.dp)
-                            .padding(vertical = 10.dp),
+                            .padding(10.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.SpaceAround
                     ) {
@@ -135,10 +134,10 @@ fun HomeScreen(
             }
 
         }
-        if (openLogoutDialog) {
+        if (openExitDialog) {
 
             Dialog(
-                onDismissRequest = { openLogoutDialog = false },
+                onDismissRequest = { openExitDialog = false },
                 properties = DialogProperties(usePlatformDefaultWidth = false)
 
             ) {
@@ -160,10 +159,10 @@ fun HomeScreen(
                         verticalArrangement = Arrangement.SpaceAround
                     ) {
 
-                        SubHeading(text = stringResource(R.string.logout), color = holoGreen)
+                        SubHeading(text = stringResource(R.string.exit), color = holoGreen)
 
                         Title(
-                            text = stringResource(R.string.logout_alert_text),
+                            text = stringResource(R.string.exit_alert_text),
 
                             )
 
@@ -176,14 +175,14 @@ fun HomeScreen(
                         ) {
 
                             RegularButton(text = stringResource(R.string.confirm), onClick = {
-                                userViewModel.logOut()
+                                /*userViewModel.logOut()
                                 openLogoutDialog = false
-                                navController.navigateUp()
-
+                                navController.navigateUp()*/
+                                ctx?.finish()
                             })
 
                             RegularButton(text = stringResource(R.string.dismiss), onClick = {
-                                openLogoutDialog = false
+                                openExitDialog = false
                             })
 
                         }

--- a/app/src/main/java/com/business/fityou/ui/composables/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/business/fityou/ui/composables/onboarding/OnboardingScreen.kt
@@ -43,9 +43,13 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import com.business.fityou.R
 import com.business.fityou.ui.navigation.Screens
 import com.business.fityou.ui.theme.BackgroundCreamWhite
+import kotlin.reflect.KFunction0
 
 @Composable
-fun OnboardingScreen(navController: NavController) {
+fun OnboardingScreen(
+    navController: NavController,
+    noLongerFirstTimeFunc: KFunction0<Unit>
+) {
     val context = LocalContext.current
     var currentPage by remember { mutableStateOf(0) }
 
@@ -111,9 +115,10 @@ fun OnboardingScreen(navController: NavController) {
                 .fillMaxWidth(),
             onClick = {
                 if (currentPage < 2) currentPage++
-                else navController.navigate(Screens.Login.route) {
-                    popUpTo(Screens.Onboarding.route) {
-                        inclusive = true
+                else {
+                    noLongerFirstTimeFunc()
+                    navController.navigate(Screens.Login.route) {
+                        popUpTo(navController.graph.id) { inclusive = true }
                     }
                 }
             }

--- a/app/src/main/java/com/business/fityou/ui/composables/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/business/fityou/ui/composables/settings/SettingsScreen.kt
@@ -8,19 +8,19 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,32 +28,67 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.business.fityou.R
 import com.business.fityou.ui.composables.RadioButtons
+import com.business.fityou.ui.composables.RegularButton
+import com.business.fityou.ui.composables.home.SubHeading
+import com.business.fityou.ui.composables.home.Title
 import com.business.fityou.ui.theme.DynamicThemes
+import com.business.fityou.ui.theme.darkBlue
+import com.business.fityou.ui.theme.holoGreen
 import com.business.fityou.ui.theme.toDynamicTheme
 import com.business.fityou.ui.theme.toName
 import com.business.fityou.viewmodel.SettingsViewModel
 import kotlin.reflect.KFunction0
-import kotlin.reflect.KFunction1
 
 @Composable
 fun SettingsScreen(
-    vm: SettingsViewModel,
+    settingsViewModel: SettingsViewModel,
     onSignOut: KFunction0<Unit>
 ) {
     var itemThemeOpened by remember{ mutableStateOf(false) }
+    var itemLogoutOpened by remember{ mutableStateOf(false) }
 
     Column(
         modifier = Modifier.verticalScroll(rememberScrollState())
     ) {
-        ItemTheme(currentTheme = vm.currentTheme) { itemThemeOpened = true }
+        ItemTheme(currentTheme = settingsViewModel.currentTheme) { itemThemeOpened = true }
+        ItemLogout{ itemLogoutOpened = true }
     }
 
     if (itemThemeOpened) ThemeSelectionDialog(
-        currentTheme = vm.currentTheme,
+        currentTheme = settingsViewModel.currentTheme,
         onDismiss = { itemThemeOpened = false },
-        onSelect = { vm.setTheme(it) }
+        onSelect = { settingsViewModel.setTheme(it) }
     )
+
+    if (itemLogoutOpened) LogoutConfirmDialog(
+        onDismiss = { itemLogoutOpened = false },
+        onConfirm = { onSignOut() }
+    )
+}
+
+@Composable
+private fun SettingsItem(
+    label: String,
+    onClick: () -> Unit
+) {
+    TextButton(onClick) {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = label,
+                color = MaterialTheme.colors.onBackground
+            )
+            Icon(Icons.Filled.ArrowForward, "", tint = MaterialTheme.colors.onBackground)
+        }
+    }
 }
 
 @Composable
@@ -61,21 +96,20 @@ private fun ItemTheme(
     currentTheme: DynamicThemes?,
     onOpen: () -> Unit
 ) {
-    TextButton(
-        onOpen
-    ) {
-        Row(
-            Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                "Theme: ${currentTheme?.toName() ?: "System Default"}",
-                color = MaterialTheme.colors.onBackground
-            )
-            Icon(Icons.Filled.ArrowForward, "", tint = MaterialTheme.colors.onBackground)
-        }
-    }
+    SettingsItem(
+        label = "Theme: ${currentTheme?.toName() ?: "System Default"}",
+        onClick = onOpen
+    )
 }
+
+@Composable
+private fun ItemLogout(
+    openDialog: () -> Unit
+) {
+    SettingsItem(label = "Log out", onClick = openDialog)
+}
+
+
 
 @Composable
 private fun ThemeSelectionDialog(
@@ -98,6 +132,45 @@ private fun ThemeSelectionDialog(
                 if (this != currentTheme) {
                     onSelect(this)
                     onDismiss()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogoutConfirmDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            modifier = Modifier.padding(vertical = 8.dp, horizontal = 15.dp),
+            color = darkBlue,
+            elevation = 20.dp,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(300.dp)
+                    .padding(10.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.SpaceAround
+            ) {
+                SubHeading(text = stringResource(R.string.logout), color = holoGreen)
+                Title(stringResource(R.string.logout_alert_text))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement
+                        .spacedBy(20.dp, Alignment.CenterHorizontally)
+                ) {
+                    RegularButton(text = stringResource(R.string.confirm), onClick = onConfirm)
+                    RegularButton(text = stringResource(R.string.dismiss), onClick = onDismiss)
                 }
             }
         }

--- a/app/src/main/java/com/business/fityou/ui/navigation/LoginNavGraph.kt
+++ b/app/src/main/java/com/business/fityou/ui/navigation/LoginNavGraph.kt
@@ -17,13 +17,16 @@ fun NavGraphBuilder.loginNavGraph(
     userViewModel: UserViewModel,
     scaffoldState: ScaffoldState
 ) {
-
-    navigation(startDestination = Screens.Onboarding.route, route = LOGIN_ROUTE)
-    {
+    navigation(
+        startDestination =
+            if (userViewModel.isFirstTime()) Screens.Onboarding.route
+            else Screens.Login.route,
+        route = LOGIN_ROUTE
+    ) {
         composable(
             route = Screens.Onboarding.route
         ) {
-            OnboardingScreen(navController)
+            OnboardingScreen(navController, userViewModel::noLongerFirstTime)
             bottomBarState.value = false
         }
 
@@ -31,6 +34,7 @@ fun NavGraphBuilder.loginNavGraph(
             LoginScreen(navController, userViewModel, scaffoldState)
             bottomBarState.value = false
         }
+
         composable(route = Screens.Signup.route) {
             SignUpScreen(navController, userViewModel, scaffoldState)
             bottomBarState.value = false

--- a/app/src/main/java/com/business/fityou/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/business/fityou/ui/navigation/MainNavGraph.kt
@@ -116,7 +116,10 @@ fun NavGraphBuilder.mainNavGraph(
         }
 
         composable(route = Screens.Settings.route) {
-            SettingsScreen(vm = settingsViewModel, onSignOut = userViewModel::logOut)
+            SettingsScreen(
+                settingsViewModel = settingsViewModel,
+                onSignOut = userViewModel::logOut
+            )
             bottomBarState.value = true
         }
     }
@@ -181,7 +184,7 @@ fun RowScope.AddItem(
 
         onClick = {
             navController.navigate(screens.route) {
-                popUpTo(navController.graph.findStartDestination().id)
+                popUpTo(Screens.Home.route)
                 launchSingleTop = true
             }
         },

--- a/app/src/main/java/com/business/fityou/ui/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/business/fityou/ui/navigation/RootNavGraph.kt
@@ -40,7 +40,9 @@ fun RootNavGraph(
 
     LaunchedEffect(Unit) { userViewModel.checkLoginState() }
     LaunchedEffect(userViewModel.signInState) {
-        if (userViewModel.signInState.success) navController.navigate(MAIN_ROUTE)
+        if (userViewModel.signInState.success) navController.navigate(MAIN_ROUTE) {
+            popUpTo(Screens.Home.route) { inclusive = true }
+        }
         else navController.navigate(LOGIN_ROUTE) {
             popUpTo(navController.graph.id) { inclusive = true }
         }

--- a/app/src/main/java/com/business/fityou/ui/navigation/Screens.kt
+++ b/app/src/main/java/com/business/fityou/ui/navigation/Screens.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.rounded.Analytics
 import androidx.compose.material.icons.rounded.FitnessCenter
 import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.business.fityou.R
 

--- a/app/src/main/java/com/business/fityou/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/business/fityou/viewmodel/UserViewModel.kt
@@ -158,6 +158,9 @@ class UserViewModel @Inject constructor(
         }
     }
 
+    fun isFirstTime(): Boolean = repository.isFirstTime()
+    fun noLongerFirstTime() = repository.noLongerFirstTime()
+
 
     fun logOut() {
         viewModelScope.launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,7 +80,9 @@
     <string name="dumbbells">Dumbbells</string>
     <string name="equipment">equipment</string>
     <string name="logout">Logout</string>
-    <string name="logout_alert_text">are you sure you want to logout?</string>
+    <string name="logout_alert_text">Are you sure you want to log out?</string>
+    <string name="exit">Close App</string>
+    <string name="exit_alert_text">You\'re about to exit the app</string>
     <string name="google_sign_in_error1">Server is still signing out the user</string>
 
     <string name="onboarding_title_one">Welcome to Fit You</string>


### PR DESCRIPTION
- Log out now officially (heh) moves to the settings screen instead of a back press in the home screen
- Pressing back in home screen instead exits the app
- Pressing back in other screens moves back to home screen
- Pressing back after finishing onboarding now closes the app instead of going back to that screen
- Onboarding now only shows on first time use of the app. Subsequent entrance now goes to login page or main page directly
- Fix broadcast receiver not unregistering